### PR TITLE
Use ld instead of gcc for linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CROSS_COMPILE ?= arm-none-eabi-
 
 CC = $(CROSS_COMPILE)gcc
+LD = $(CROSS_COMPILE)ld
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
 SIZE = $(CROSS_COMPILE)size
@@ -10,7 +11,7 @@ OPENOCD = openocd
 CFLAGS := -mthumb -mcpu=cortex-m4
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -Os -std=gnu99 -Wall
-LDFLAGS := -nostartfiles -Wl,--gc-sections
+LINKERFLAGS := -nostartfiles --gc-sections
 
 obj-y += gpio.o mpu.o
 obj-f4 += $(obj-y) usart-f4.o
@@ -22,22 +23,22 @@ all: stm32f429i-disco stm32429i-eval stm32f469i-disco stm32746g-eval
 	$(CC) -c $(CFLAGS) $< -o $@
 
 stm32f429i-disco: stm32f429i-disco.o $(obj-f4)
-	$(CC) -T stm32f429.lds $(LDFLAGS) -o stm32f429i-disco.elf stm32f429i-disco.o $(obj-f4)
+	$(LD) -T stm32f429.lds $(LINKERFLAGS) -o stm32f429i-disco.elf stm32f429i-disco.o $(obj-f4)
 	$(OBJCOPY) -Obinary stm32f429i-disco.elf stm32f429i-disco.bin
 	$(SIZE) stm32f429i-disco.elf
 
 stm32429i-eval: stm32429i-eval.o $(obj-f4)
-	$(CC) -T stm32f429.lds $(LDFLAGS) -o stm32429i-eval.elf stm32429i-eval.o $(obj-f4)
+	$(LD) -T stm32f429.lds $(LINKERFLAGS) -o stm32429i-eval.elf stm32429i-eval.o $(obj-f4)
 	$(OBJCOPY) -Obinary stm32429i-eval.elf stm32429i-eval.bin
 	$(SIZE) stm32429i-eval.elf
 
 stm32f469i-disco: stm32f469i-disco.o $(obj-f4)
-	$(CC) -T stm32f429.lds $(LDFLAGS) -o stm32f469i-disco.elf stm32f469i-disco.o $(obj-f4)
+	$(LD) -T stm32f429.lds $(LINKERFLAGS) -o stm32f469i-disco.elf stm32f469i-disco.o $(obj-f4)
 	$(OBJCOPY) -Obinary stm32f469i-disco.elf stm32f469i-disco.bin
 	$(SIZE) stm32f469i-disco.elf
 
 stm32746g-eval: stm32746g-eval.o $(obj-f7)
-	$(CC) -T stm32f429.lds $(LDFLAGS) -o stm32746g-eval.elf stm32746g-eval.o $(obj-f7)
+	$(LD) -T stm32f429.lds $(LINKERFLAGS) -o stm32746g-eval.elf stm32746g-eval.o $(obj-f7)
 	$(OBJCOPY) -Obinary stm32746g-eval.elf stm32746g-eval.bin
 	$(SIZE) stm32746g-eval.elf
 


### PR DESCRIPTION
Using gcc for linking is indeed normally the right choice. It works
fine when using a bare metal arm-none-eabi toolchain.

However, in build systems like Buildroot, we don't have two separate
toolchains, one bare-metal to build bootloader(s) and the kernel, and
one targetting Linux to build userspace libraries/binaries. We use a
single toolchain targetting Linux, which is normally perfectly capable
of building bare-metal code (U-Boot, Barebox, Linux kernel).

Unfortunately, afboot-stm32 doesn't link properly with a Linux FLAT
toolchain, with the following error:

arm-buildroot-uclinux-uclibcgnueabi-gcc -T stm32f429.lds -nostartfiles -Wl,--gc-sections -o stm32f429i-disco.elf stm32f429i-disco.o gpio.o mpu.o usart-f4.o
ERROR: text=0x454 overlaps data=0x8000000 ?

This is due to gcc trying to generate a FLAT binary, rather than an
ELF file as expected by the afboot-stm32 build process. Since there is
apparently no flag to tell gcc to not produce a FLAT binary, the only
option is to directly call ld.

This problem was reproduced using both a Cortex-M4 toolchain built by
Buildroot, or a pre-built Cortex-M3 toolchain provided by OSELAS
toolchains.

In addition to using 'ld' directly instead of 'gcc', we rename LDFLAGS
to LINKERFLAGS to make it clear that those flags are directly flags
for the linker (while LDFLAGS, contrary to what its name suggests, are
flags for gcc when called for the link step).

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
