### PR TITLE
fix compilation errors for linker and builtin libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ KERNEL_ADDR?=0x08008000
 DTB_ADDR?=0x08004000
 
 CFLAGS := -mthumb -mcpu=cortex-m4
-CFLAGS += -ffunction-sections -fdata-sections
+CFLAGS += -ffunction-sections -fdata-sections -fno-builtin
 CFLAGS += -Os -std=gnu99 -Wall
-LINKERFLAGS := -nostartfiles --gc-sections
+LINKERFLAGS := --gc-sections
 
 obj-y += gpio.o mpu.o qspi.o start_kernel.o
 obj-f4 += $(obj-y) usart-f4.o


### PR DESCRIPTION
in gcc 10 or newer, there is no option `-nostartfiles`, if you wanna use it, linker will return you a compilation Error, we need to remove this option

`undefined reference to `memset'`:  add `-fno-builtin` in CFLAGS

I encountered these two errors when I was writing an tiny-os for stm32 several years ago, this is my solution